### PR TITLE
BACKLOG-15292 changed url to be render instead of editframe and update signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.classpath
 /.project
 /.settings
+.DS_Store
 .idea
 *.iml
 *.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <export-package>org.jahia.modules.jahiaauth.service,org.jahia.modules.jahiaauth.action,org.jahia.modules.jahiaauth.tag</export-package>
         <jahia-static-resources>/css,/javascript,/icons</jahia-static-resources>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFH9ubazKSz5KVtL1Ljvjo91K96W1AhR3WIV3EPBZyiHFYZuCHY/GiW1bQQ==</jahia-module-signature>
+        <jahia-module-signature>MCwCFH3XFi560/1vu1zKOtUcFVJFHkLmAhQIqj6EKXXqxgjGnD2wyZwv1HZJdQ==</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
     </properties>
 

--- a/src/main/resources/javascript/apps/register.js
+++ b/src/main/resources/javascript/apps/register.js
@@ -6,6 +6,6 @@
         label: 'jahia-authentication:label',
         isSelectable: true,
         requireModuleInstalledOnSite: 'jahia-authentication',
-        iframeUrl: window.contextJsParameters.contextPath + '/cms/editframe/default/$lang/sites/$site-key.auth-connector-site-settings.html?redirect=false'
+        iframeUrl: window.contextJsParameters.contextPath + '/cms/render/default/$lang/sites/$site-key.auth-connector-site-settings.html?redirect=false'
     });
 })();


### PR DESCRIPTION


## JIRA
https://jira.jahia.org/browse/BACKLOG-15292

## Description
To give some context, the remote publication server doesn't have access to the `editframe` URL and makes it impossible to have access for site configurations, e.g authentication. Changing the URL to `render` works on the authoring instance and fixes the blank screen on the remote publication instance.
