### PR TITLE
QA-13939 Use logger instead of e.printStackTrace()

### DIFF
--- a/src/main/java/org/jahia/modules/jahiaauth/action/ManageConnectorsSettings.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/action/ManageConnectorsSettings.java
@@ -45,8 +45,6 @@ package org.jahia.modules.jahiaauth.action;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
-import org.apache.pdfbox.jbig2.util.log.Logger;
-import org.apache.pdfbox.jbig2.util.log.LoggerFactory;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.modules.jahiaauth.impl.SettingsServiceImpl;
@@ -63,6 +61,8 @@ import org.jahia.tools.files.FileUpload;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/org/jahia/modules/jahiaauth/service/ConnectorConfig.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/service/ConnectorConfig.java
@@ -3,11 +3,13 @@ package org.jahia.modules.jahiaauth.service;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
 public class ConnectorConfig {
-
+    private static final Logger logger = LoggerFactory.getLogger(ConnectorConfig.class);
     private Settings settings;
     private Settings.Values values;
     private List<MapperConfig> mappers = new ArrayList<>();
@@ -19,7 +21,7 @@ public class ConnectorConfig {
         try {
             initMappers(settings);
         } catch (JSONException e) {
-            e.printStackTrace();
+            logger.warn("Error initializing authentication mappers", e);
         }
     }
 


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13939

## Description

Use logger instead of e.printStackTrace()
