### PR TITLE
BACKLOG-15401: Split actions into read and write action classes

### DIFF
--- a/src/main/java/org/jahia/modules/jahiaauth/action/ReadConnectorsSettings.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/action/ReadConnectorsSettings.java
@@ -43,52 +43,36 @@
  */
 package org.jahia.modules.jahiaauth.action;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.FileUtils;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.modules.jahiaauth.impl.SettingsServiceImpl;
-import org.jahia.modules.jahiaauth.service.ConnectorConfig;
-import org.jahia.modules.jahiaauth.service.ConnectorService;
 import org.jahia.modules.jahiaauth.service.JahiaAuthConstants;
 import org.jahia.modules.jahiaauth.service.Settings;
-import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
-import org.jahia.tools.files.FileUpload;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * @author dgaillard
  */
-public class ManageConnectorsSettings extends Action {
+public class ReadConnectorsSettings extends Action {
     public static final String ERROR = "error";
     public static final String REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST = "required properties are missing in the request";
-    private static final Logger logger = LoggerFactory.getLogger(ManageConnectorsSettings.class);
     private SettingsServiceImpl settingsService;
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
         // Get registered data
-        if (req.getMethod().equals(JahiaAuthConstants.METHOD_GET)) {
-            return getSettings(renderContext, parameters);
-        } else {
-            return updateData(req, renderContext, parameters);
-        }
+        return getSettings(renderContext, parameters);
     }
 
     private ActionResult getSettings(RenderContext renderContext, Map<String, List<String>> parameters) throws JSONException {
@@ -121,66 +105,6 @@ public class ManageConnectorsSettings extends Action {
             }
         }
         return new ActionResult(HttpServletResponse.SC_OK, null, response);
-    }
-
-    private ActionResult updateData(HttpServletRequest req, RenderContext renderContext, Map<String, List<String>> parameters) throws JSONException {
-        JSONObject response = new JSONObject();
-        // Register or update data
-        if (!parameters.containsKey(JahiaAuthConstants.CONNECTOR_SERVICE_NAME) || !parameters.containsKey(JahiaAuthConstants.PROPERTIES) || parameters.get(JahiaAuthConstants.PROPERTIES).isEmpty()) {
-            response.put(ERROR, REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST);
-            return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
-        }
-
-        try {
-            String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).get(0);
-            ConnectorService connectorService = BundleUtils.getOsgiService(ConnectorService.class, "(" + JahiaAuthConstants.CONNECTOR_SERVICE_NAME + "=" + connectorServiceName + ")");
-
-            FileUpload fup = (FileUpload) req.getAttribute("fileUpload");
-
-            Map<String, Object> properties = new ObjectMapper().readValue(parameters.get(JahiaAuthConstants.PROPERTIES).get(0), HashMap.class);
-            if (!properties.containsKey(JahiaAuthConstants.PROPERTY_IS_ENABLED)) {
-                response.put(ERROR, REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST);
-                return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
-            }
-
-            Settings settings = updateSettings(renderContext, connectorServiceName, fup, properties);
-
-            connectorService.validateSettings(new ConnectorConfig(settings, connectorServiceName));
-
-            settingsService.storeSettings(settings);
-            return new ActionResult(HttpServletResponse.SC_OK, null, response);
-        } catch (Exception e) {
-            JSONObject error = new JSONObject();
-            if (logger.isDebugEnabled()) {
-                logger.debug("error while saving settings", e);
-            }
-            if (e.getMessage() != null) {
-                error.put(ERROR, e.getMessage());
-                if (e.getCause() != null && e.getCause().getMessage() != null) {
-                    error.put(ERROR, e.getMessage() + " - " + e.getCause().getMessage());
-                }
-            } else {
-                error.put(ERROR, "Error when saving");
-            }
-            error.put("type", e.getClass().getSimpleName());
-            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, error);
-        }
-    }
-
-    private Settings updateSettings(RenderContext renderContext, String connectorServiceName, FileUpload fup, Map<String, Object> properties) throws IOException {
-        Settings settings = settingsService.getSettings(renderContext.getSite().getSiteKey());
-        Settings.Values v = settings.getValues(connectorServiceName);
-        for (Map.Entry<String, Object> entry : properties.entrySet()) {
-            if (fup.getFileItems().containsKey("file_" + entry.getKey())) {
-                File s = fup.getFileItems().get("file_" + entry.getKey()).getStoreLocation();
-                v.setBinaryProperty(entry.getKey(), FileUtils.readFileToByteArray(s));
-            } else if (entry.getValue() instanceof List) {
-                v.setListProperty(entry.getKey(), (List) entry.getValue());
-            } else {
-                v.setProperty(entry.getKey(), entry.getValue().toString());
-            }
-        }
-        return settings;
     }
 
     public void setSettingsService(SettingsServiceImpl settingsService) {

--- a/src/main/java/org/jahia/modules/jahiaauth/action/ReadMappers.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/action/ReadMappers.java
@@ -1,0 +1,160 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.modules.jahiaauth.action;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jahia.bin.Action;
+import org.jahia.bin.ActionResult;
+import org.jahia.modules.jahiaauth.impl.SettingsServiceImpl;
+import org.jahia.modules.jahiaauth.service.*;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.URLResolver;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * @author dgaillard
+ */
+public class ReadMappers extends Action {
+    public static final String ERROR = "error";
+    private SettingsService settingsService;
+
+    @Override
+    public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
+                                  JCRSessionWrapper session, Map<String, List<String>> parameters,
+                                  URLResolver urlResolver) throws Exception {
+        JsonNode params = new ObjectMapper().readTree(req.getInputStream());
+        String action = params.get("action").asText();
+        switch (action) {
+            case "getConnectorProperties":
+                return getConnectorProperties(params);
+            case "getMapperProperties":
+                return getMapperProperties(params);
+            case "getMapperMapping":
+                return getMapperMapping(renderContext, params);
+            default:
+                return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject());
+        }
+    }
+
+    private ActionResult getMapperMapping(RenderContext renderContext, JsonNode parameters) throws JSONException {
+        JSONObject response = new JSONObject();
+        if (!parameters.hasNonNull(JahiaAuthConstants.MAPPER_SERVICE_NAME)
+                || !parameters.hasNonNull(JahiaAuthConstants.CONNECTOR_SERVICE_NAME)) {
+            response.put(ERROR, "required properties are missing in the request");
+            return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
+        }
+
+        String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).asText();
+        String mapperServiceName = parameters.get(JahiaAuthConstants.MAPPER_SERVICE_NAME).asText();
+
+        Settings settings = settingsService.getSettings(renderContext.getSite().getSiteKey());
+        Settings.Values mapperNode = settings.getValues(connectorServiceName).getSubValues(JahiaAuthConstants.MAPPERS_NODE_NAME).getSubValues(mapperServiceName);
+
+        if (mapperNode.isEmpty()) {
+            return new ActionResult(HttpServletResponse.SC_OK, null, response);
+        }
+
+        JSONArray jsonArrayMapping = new JSONArray(mapperNode.getProperty(JahiaAuthConstants.PROPERTY_MAPPING));
+        response.put(JahiaAuthConstants.PROPERTY_IS_ENABLED, mapperNode.getBooleanProperty(JahiaAuthConstants.PROPERTY_IS_ENABLED));
+        response.put(JahiaAuthConstants.PROPERTY_MAPPING, jsonArrayMapping);
+
+        if (parameters.get(JahiaAuthConstants.PROPERTIES) != null) {
+            for (Iterator<String> it = parameters.get(JahiaAuthConstants.PROPERTIES).fieldNames(); it.hasNext(); ) {
+                String property = it.next();
+                if (!mapperNode.getListProperty(property).isEmpty()) {
+                    JSONArray array = new JSONArray();
+                    mapperNode.getListProperty(property).forEach(array::put);
+                    response.put(property, array);
+                } else if (mapperNode.getProperty(property) != null) {
+                    if (property.equals(JahiaAuthConstants.PROPERTY_IS_ENABLED)) {
+                        response.put(property, Boolean.valueOf(mapperNode.getProperty(property)));
+                    } else {
+                        response.put(property, mapperNode.getProperty(property));
+                    }
+                }
+            }
+        }
+
+        return new ActionResult(HttpServletResponse.SC_OK, null, response);
+    }
+
+    private ActionResult getMapperProperties(JsonNode parameters) throws JSONException {
+        JSONObject response = new JSONObject();
+        String mapperServiceName = parameters.get(JahiaAuthConstants.MAPPER_SERVICE_NAME).asText();
+        Mapper mapperService = BundleUtils.getOsgiService(Mapper.class, "(" + JahiaAuthConstants.MAPPER_SERVICE_NAME + "=" + mapperServiceName + ")");
+        if (mapperService == null) {
+            response.put(ERROR, "Cannot find connector");
+            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, response);
+        }
+        response.put("mapperProperties", new JSONArray(mapperService.getProperties().stream().map(JSONObject::new).collect(Collectors.toList())));
+        return new ActionResult(HttpServletResponse.SC_OK, null, response);
+    }
+
+    private ActionResult getConnectorProperties(JsonNode parameters) throws JSONException {
+        JSONObject response = new JSONObject();
+        String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).asText();
+        ConnectorService connectorService = BundleUtils.getOsgiService(ConnectorService.class, "(" + JahiaAuthConstants.CONNECTOR_SERVICE_NAME + "=" + connectorServiceName + ")");
+        if (connectorService == null) {
+            response.put(ERROR, "Cannot find connector");
+            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, response);
+        }
+        response.put("connectorProperties", new JSONArray(connectorService.getAvailableProperties().stream().map(JSONObject::new).collect(Collectors.toList())));
+        return new ActionResult(HttpServletResponse.SC_OK, null, response);
+    }
+
+    public void setSettingsService(SettingsServiceImpl settingsService) {
+        this.settingsService = settingsService;
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiaauth/action/WriteConnectorsSettings.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/action/WriteConnectorsSettings.java
@@ -1,0 +1,151 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.modules.jahiaauth.action;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FileUtils;
+import org.jahia.bin.Action;
+import org.jahia.bin.ActionResult;
+import org.jahia.modules.jahiaauth.impl.SettingsServiceImpl;
+import org.jahia.modules.jahiaauth.service.ConnectorConfig;
+import org.jahia.modules.jahiaauth.service.ConnectorService;
+import org.jahia.modules.jahiaauth.service.JahiaAuthConstants;
+import org.jahia.modules.jahiaauth.service.Settings;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.URLResolver;
+import org.jahia.tools.files.FileUpload;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author dgaillard
+ */
+public class WriteConnectorsSettings extends Action {
+    public static final String ERROR = "error";
+    public static final String REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST = "required properties are missing in the request";
+    private static final Logger logger = LoggerFactory.getLogger(WriteConnectorsSettings.class);
+    private SettingsServiceImpl settingsService;
+
+    @Override
+    public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
+        return updateData(req, renderContext, parameters);
+    }
+
+    private ActionResult updateData(HttpServletRequest req, RenderContext renderContext, Map<String, List<String>> parameters) throws JSONException {
+        JSONObject response = new JSONObject();
+        // Register or update data
+        if (!parameters.containsKey(JahiaAuthConstants.CONNECTOR_SERVICE_NAME) || !parameters.containsKey(JahiaAuthConstants.PROPERTIES) || parameters.get(JahiaAuthConstants.PROPERTIES).isEmpty()) {
+            response.put(ERROR, REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST);
+            return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
+        }
+
+        try {
+            String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).get(0);
+            ConnectorService connectorService = BundleUtils.getOsgiService(ConnectorService.class, "(" + JahiaAuthConstants.CONNECTOR_SERVICE_NAME + "=" + connectorServiceName + ")");
+
+            FileUpload fup = (FileUpload) req.getAttribute("fileUpload");
+
+            Map<String, Object> properties = new ObjectMapper().readValue(parameters.get(JahiaAuthConstants.PROPERTIES).get(0), HashMap.class);
+            if (!properties.containsKey(JahiaAuthConstants.PROPERTY_IS_ENABLED)) {
+                response.put(ERROR, REQUIRED_PROPERTIES_ARE_MISSING_IN_THE_REQUEST);
+                return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
+            }
+
+            Settings settings = updateSettings(renderContext, connectorServiceName, fup, properties);
+
+            connectorService.validateSettings(new ConnectorConfig(settings, connectorServiceName));
+
+            settingsService.storeSettings(settings);
+            return new ActionResult(HttpServletResponse.SC_OK, null, response);
+        } catch (Exception e) {
+            JSONObject error = new JSONObject();
+            if (logger.isDebugEnabled()) {
+                logger.debug("error while saving settings", e);
+            }
+            if (e.getMessage() != null) {
+                error.put(ERROR, e.getMessage());
+                if (e.getCause() != null && e.getCause().getMessage() != null) {
+                    error.put(ERROR, e.getMessage() + " - " + e.getCause().getMessage());
+                }
+            } else {
+                error.put(ERROR, "Error when saving");
+            }
+            error.put("type", e.getClass().getSimpleName());
+            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, error);
+        }
+    }
+
+    private Settings updateSettings(RenderContext renderContext, String connectorServiceName, FileUpload fup, Map<String, Object> properties) throws IOException {
+        Settings settings = settingsService.getSettings(renderContext.getSite().getSiteKey());
+        Settings.Values v = settings.getValues(connectorServiceName);
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (fup.getFileItems().containsKey("file_" + entry.getKey())) {
+                File s = fup.getFileItems().get("file_" + entry.getKey()).getStoreLocation();
+                v.setBinaryProperty(entry.getKey(), FileUtils.readFileToByteArray(s));
+            } else if (entry.getValue() instanceof List) {
+                v.setListProperty(entry.getKey(), (List) entry.getValue());
+            } else {
+                v.setProperty(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        return settings;
+    }
+
+    public void setSettingsService(SettingsServiceImpl settingsService) {
+        this.settingsService = settingsService;
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiaauth/action/WriteMappers.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/action/WriteMappers.java
@@ -51,12 +51,10 @@ import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.modules.jahiaauth.impl.SettingsServiceImpl;
 import org.jahia.modules.jahiaauth.service.*;
-import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -64,12 +62,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
+
 
 /**
  * @author dgaillard
  */
-public class ManageMappers extends Action {
+public class WriteMappers extends Action {
     public static final String ERROR = "error";
     private SettingsService settingsService;
 
@@ -77,20 +75,7 @@ public class ManageMappers extends Action {
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
                                   JCRSessionWrapper session, Map<String, List<String>> parameters,
                                   URLResolver urlResolver) throws Exception {
-        JsonNode params = new ObjectMapper().readTree(req.getInputStream());
-        String action = params.get("action").asText();
-        switch (action) {
-            case "getConnectorProperties":
-                return getConnectorProperties(params);
-            case "getMapperProperties":
-                return getMapperProperties(params);
-            case "getMapperMapping":
-                return getMapperMapping(renderContext, params);
-            case "setMapperMapping":
-                return setMapperMapping(renderContext, params);
-            default:
-                return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject());
-        }
+        return setMapperMapping(renderContext, new ObjectMapper().readTree(req.getInputStream()));
     }
 
     private ActionResult setMapperMapping(RenderContext renderContext, JsonNode parameters) throws JSONException, IOException {
@@ -129,72 +114,6 @@ public class ManageMappers extends Action {
         }
 
         settingsService.storeSettings(settings);
-        return new ActionResult(HttpServletResponse.SC_OK, null, response);
-    }
-
-    private ActionResult getMapperMapping(RenderContext renderContext, JsonNode parameters) throws JSONException {
-        JSONObject response = new JSONObject();
-        if (!parameters.hasNonNull(JahiaAuthConstants.MAPPER_SERVICE_NAME)
-                || !parameters.hasNonNull(JahiaAuthConstants.CONNECTOR_SERVICE_NAME)) {
-            response.put(ERROR, "required properties are missing in the request");
-            return new ActionResult(HttpServletResponse.SC_BAD_REQUEST, null, response);
-        }
-
-        String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).asText();
-        String mapperServiceName = parameters.get(JahiaAuthConstants.MAPPER_SERVICE_NAME).asText();
-
-        Settings settings = settingsService.getSettings(renderContext.getSite().getSiteKey());
-        Settings.Values mapperNode = settings.getValues(connectorServiceName).getSubValues(JahiaAuthConstants.MAPPERS_NODE_NAME).getSubValues(mapperServiceName);
-
-        if (mapperNode.isEmpty()) {
-            return new ActionResult(HttpServletResponse.SC_OK, null, response);
-        }
-
-        JSONArray jsonArrayMapping = new JSONArray(mapperNode.getProperty(JahiaAuthConstants.PROPERTY_MAPPING));
-        response.put(JahiaAuthConstants.PROPERTY_IS_ENABLED, mapperNode.getBooleanProperty(JahiaAuthConstants.PROPERTY_IS_ENABLED));
-        response.put(JahiaAuthConstants.PROPERTY_MAPPING, jsonArrayMapping);
-
-        if (parameters.get(JahiaAuthConstants.PROPERTIES) != null) {
-            for (Iterator<String> it = parameters.get(JahiaAuthConstants.PROPERTIES).fieldNames(); it.hasNext(); ) {
-                String property = it.next();
-                if (!mapperNode.getListProperty(property).isEmpty()) {
-                    JSONArray array = new JSONArray();
-                    mapperNode.getListProperty(property).forEach(array::put);
-                    response.put(property, array);
-                } else if (mapperNode.getProperty(property) != null) {
-                    if (property.equals(JahiaAuthConstants.PROPERTY_IS_ENABLED)) {
-                        response.put(property, Boolean.valueOf(mapperNode.getProperty(property)));
-                    } else {
-                        response.put(property, mapperNode.getProperty(property));
-                    }
-                }
-            }
-        }
-
-        return new ActionResult(HttpServletResponse.SC_OK, null, response);
-    }
-
-    private ActionResult getMapperProperties(JsonNode parameters) throws JSONException {
-        JSONObject response = new JSONObject();
-        String mapperServiceName = parameters.get(JahiaAuthConstants.MAPPER_SERVICE_NAME).asText();
-        Mapper mapperService = BundleUtils.getOsgiService(Mapper.class, "(" + JahiaAuthConstants.MAPPER_SERVICE_NAME + "=" + mapperServiceName + ")");
-        if (mapperService == null) {
-            response.put(ERROR, "Cannot find connector");
-            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, response);
-        }
-        response.put("mapperProperties", new JSONArray(mapperService.getProperties().stream().map(JSONObject::new).collect(Collectors.toList())));
-        return new ActionResult(HttpServletResponse.SC_OK, null, response);
-    }
-
-    private ActionResult getConnectorProperties(JsonNode parameters) throws JSONException {
-        JSONObject response = new JSONObject();
-        String connectorServiceName = parameters.get(JahiaAuthConstants.CONNECTOR_SERVICE_NAME).asText();
-        ConnectorService connectorService = BundleUtils.getOsgiService(ConnectorService.class, "(" + JahiaAuthConstants.CONNECTOR_SERVICE_NAME + "=" + connectorServiceName + ")");
-        if (connectorService == null) {
-            response.put(ERROR, "Cannot find connector");
-            return new ActionResult(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, null, response);
-        }
-        response.put("connectorProperties", new JSONArray(connectorService.getAvailableProperties().stream().map(JSONObject::new).collect(Collectors.toList())));
         return new ActionResult(HttpServletResponse.SC_OK, null, response);
     }
 

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-jahia-authentication.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-jahia-authentication.cfg
@@ -1,0 +1,1 @@
+whitelist = *.readConnectorsSettingsAction.do, *.readMappersAction.do

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,17 +37,33 @@
     </bean>
 
     <service interface="org.jahia.bin.Action">
-        <bean class="org.jahia.modules.jahiaauth.action.ManageConnectorsSettings">
-            <property name="name" value="manageConnectorsSettingsAction"/>
-            <property name="requiredMethods" value="GET,POST"/>
+        <bean class="org.jahia.modules.jahiaauth.action.ReadConnectorsSettings">
+            <property name="name" value="readConnectorsSettingsAction"/>
+            <property name="requiredMethods" value="GET"/>
             <property name="requiredPermission" value="canSetupJahiaAuth"/>
             <property name="settingsService" ref="settingsService"/>
         </bean>
     </service>
 
     <service interface="org.jahia.bin.Action">
-        <bean class="org.jahia.modules.jahiaauth.action.ManageMappers">
-            <property name="name" value="manageMappersAction"/>
+        <bean class="org.jahia.modules.jahiaauth.action.WriteConnectorsSettings">
+            <property name="name" value="writeConnectorsSettingsAction"/>
+            <property name="requiredPermission" value="canSetupJahiaAuth"/>
+            <property name="settingsService" ref="settingsService"/>
+        </bean>
+    </service>    
+
+    <service interface="org.jahia.bin.Action">
+        <bean class="org.jahia.modules.jahiaauth.action.ReadMappers">
+            <property name="name" value="readMappersAction"/>
+            <property name="requiredPermission" value="canSetupJahiaAuth"/>
+            <property name="settingsService" ref="settingsService"/>
+        </bean>
+    </service>
+    
+    <service interface="org.jahia.bin.Action">
+        <bean class="org.jahia.modules.jahiaauth.action.WriteMappers">
+            <property name="name" value="writeMappersAction"/>
             <property name="requiredPermission" value="canSetupJahiaAuth"/>
             <property name="settingsService" ref="settingsService"/>
         </bean>

--- a/src/main/resources/javascript/jahia-authentication/settings-service.js
+++ b/src/main/resources/javascript/jahia-authentication/settings-service.js
@@ -20,13 +20,13 @@
             angular.forEach(properties, function(property) {
                 propertiesAsString += '&properties=' + property;
             });
-            return $http.get(jahiaContext.basePreview + jahiaContext.sitePath + '.manageConnectorsSettingsAction.do?connectorServiceName=' + nodeName + propertiesAsString);
+            return $http.get(jahiaContext.basePreview + jahiaContext.sitePath + '.readConnectorsSettingsAction.do?connectorServiceName=' + nodeName + propertiesAsString);
         }
 
         function setConnectorData(data, options) {
             return $http({
                 method: 'POST',
-                url: jahiaContext.basePreview + jahiaContext.sitePath + '.manageConnectorsSettingsAction.do',
+                url: jahiaContext.basePreview + jahiaContext.sitePath + '.writeConnectorsSettingsAction.do',
                 data: data,
                 headers: {'Content-Type': undefined},
                 transformRequest: function (data) {
@@ -47,7 +47,7 @@
             data.action = 'getConnectorProperties';
             return $http({
                 method: 'POST',
-                url: jahiaContext.basePreview + jahiaContext.sitePath + '.manageMappersAction.do',
+                url: jahiaContext.basePreview + jahiaContext.sitePath + '.readMappersAction.do',
                 data: data
             })
         }
@@ -56,7 +56,7 @@
             data.action = 'getMapperProperties';
             return $http({
                 method: 'POST',
-                url: jahiaContext.basePreview + jahiaContext.sitePath + '.manageMappersAction.do',
+                url: jahiaContext.basePreview + jahiaContext.sitePath + '.readMappersAction.do',
                 data: data
             })
         }
@@ -65,7 +65,7 @@
             data.action = 'getMapperMapping';
             return $http({
                 method: 'POST',
-                url: jahiaContext.basePreview + jahiaContext.sitePath + '.manageMappersAction.do',
+                url: jahiaContext.basePreview + jahiaContext.sitePath + '.readMappersAction.do',
                 data: data
             })
         }
@@ -74,7 +74,7 @@
             data.action = 'setMapperMapping';
             return $http({
                 method: 'POST',
-                url: jahiaContext.basePreview + jahiaContext.sitePath + '.manageMappersAction.do',
+                url: jahiaContext.basePreview + jahiaContext.sitePath + '.writeMappersAction.do',
                 data: data
             })
         }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browseBACKLOG-15401

## Description

Split actions into read and write action classes
- this is necessary to make TokenPerPage work with jahia-csrf-guard

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
