### PR TITLE
refactor(auth): Use Authentication service in SSOValve

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ jobs:
     # downloading the entire world when building.
     # More on https://github.com/Jahia/cimg-mvn-cache
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
          supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.3.0</version>
+        <version>8.2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jahia-authentication</artifactId>

--- a/src/main/java/org/jahia/modules/jahiaauth/valves/SSOValve.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/valves/SSOValve.java
@@ -5,7 +5,6 @@ import org.jahia.api.usermanager.JahiaUserManagerService;
 import org.jahia.modules.jahiaauth.service.JahiaAuthConstants;
 import org.jahia.modules.jahiaauth.service.JahiaAuthMapperService;
 import org.jahia.modules.jahiaauth.service.MappedProperty;
-import org.jahia.osgi.BundleUtils;
 import org.jahia.params.valves.AuthValveContext;
 import org.jahia.params.valves.BaseAuthValve;
 import org.jahia.pipelines.Pipeline;
@@ -31,6 +30,7 @@ public class SSOValve extends BaseAuthValve {
     private JahiaUserManagerService jahiaUserManagerService;
     private JahiaAuthMapperService jahiaAuthMapperService;
     private Pipeline authPipeline;
+    private AuthenticationService authenticationService;
 
     public void start() {
         setId("ssoValve");
@@ -71,7 +71,6 @@ public class SSOValve extends BaseAuthValve {
 
         if (userNode != null) {
             try {
-                AuthenticationService authenticationService = BundleUtils.getOsgiService(AuthenticationService.class, null);
                 authenticationService.validateUserNode(userNode.getPath());
                 ok = true;
             } catch (AccountLockedException e) {
@@ -98,7 +97,6 @@ public class SSOValve extends BaseAuthValve {
             logger.debug("User {} logged in.", userNode);
         }
 
-        AuthenticationService authenticationService = BundleUtils.getOsgiService(AuthenticationService.class, null);
         boolean rememberMe = "on".equals(request.getParameter("useCookie"));
         AuthenticationOptions authenticationOptions = AuthenticationOptions.Builder.withDefaults()
                 // the check is performed later in SessionAuthValveImpl
@@ -152,5 +150,9 @@ public class SSOValve extends BaseAuthValve {
 
     public void setAuthPipeline(Pipeline authPipeline) {
         this.authPipeline = authPipeline;
+    }
+
+    public void setAuthenticationService(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
     }
 }

--- a/src/main/java/org/jahia/modules/jahiaauth/valves/SSOValve.java
+++ b/src/main/java/org/jahia/modules/jahiaauth/valves/SSOValve.java
@@ -1,42 +1,36 @@
 package org.jahia.modules.jahiaauth.valves;
 
-import org.jahia.api.Constants;
 import org.jahia.api.settings.SettingsBean;
 import org.jahia.api.usermanager.JahiaUserManagerService;
 import org.jahia.modules.jahiaauth.service.JahiaAuthConstants;
 import org.jahia.modules.jahiaauth.service.JahiaAuthMapperService;
 import org.jahia.modules.jahiaauth.service.MappedProperty;
-import org.jahia.osgi.FrameworkService;
+import org.jahia.osgi.BundleUtils;
 import org.jahia.params.valves.AuthValveContext;
 import org.jahia.params.valves.BaseAuthValve;
-import org.jahia.params.valves.CookieAuthValveImpl;
 import org.jahia.pipelines.Pipeline;
 import org.jahia.pipelines.PipelineException;
 import org.jahia.pipelines.valves.ValveContext;
 import org.jahia.services.content.decorator.JCRUserNode;
-import org.jahia.services.preferences.user.UserPreferencesHelper;
-import org.jahia.services.usermanager.JahiaUser;
-import org.jahia.utils.LanguageCodeConverters;
-import org.jahia.utils.Patterns;
+import org.jahia.services.security.AuthenticationOptions;
+import org.jahia.services.security.AuthenticationService;
+import org.jahia.services.security.ConcurrentLoggedInUsersLimitExceededLoginException;
+import org.jahia.services.security.InvalidSessionLoginException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.login.AccountLockedException;
+import javax.security.auth.login.AccountNotFoundException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class SSOValve extends BaseAuthValve {
     private static final Logger logger = LoggerFactory.getLogger(SSOValve.class);
-    private static String VALVE_RESULT = "login_valve_result";
+    private static final String VALVE_RESULT = "login_valve_result";
 
     private JahiaUserManagerService jahiaUserManagerService;
     private JahiaAuthMapperService jahiaAuthMapperService;
-    private SettingsBean settingsBean;
     private Pipeline authPipeline;
-    private String preserveSessionAttributes = null;
 
     public void start() {
         setId("ssoValve");
@@ -76,11 +70,16 @@ public class SSOValve extends BaseAuthValve {
         JCRUserNode userNode = jahiaUserManagerService.lookupUser(userId, siteKey);
 
         if (userNode != null) {
-            if (!userNode.isAccountLocked()) {
+            try {
+                AuthenticationService authenticationService = BundleUtils.getOsgiService(AuthenticationService.class, null);
+                authenticationService.validateUserNode(userNode.getPath());
                 ok = true;
-            } else {
+            } catch (AccountLockedException e) {
                 logger.warn("Login failed: account for user {} is locked.", userNode.getName());
                 request.setAttribute(VALVE_RESULT, "account_locked");
+            } catch (ConcurrentLoggedInUsersLimitExceededLoginException e) {
+                logger.warn("Login failed. Maximum number of logged in users reached for {}", userNode.getName());
+                request.setAttribute(VALVE_RESULT, "logged_in_users_limit_reached");
             }
         } else {
             logger.warn("Login failed. Unknown username {}", userId);
@@ -99,42 +98,30 @@ public class SSOValve extends BaseAuthValve {
             logger.debug("User {} logged in.", userNode);
         }
 
-        // if there are any attributes to conserve between session, let's copy them into a map first
-        Map<String, Serializable> savedSessionAttributes = preserveSessionAttributes(request);
+        AuthenticationService authenticationService = BundleUtils.getOsgiService(AuthenticationService.class, null);
+        boolean rememberMe = "on".equals(request.getParameter("useCookie"));
+        AuthenticationOptions authenticationOptions = AuthenticationOptions.Builder.withDefaults()
+                // the check is performed later in SessionAuthValveImpl
+                .sessionValidityCheckEnabled(false)
+                // pass the "remember me" flag
+                .shouldRememberMe(rememberMe).build();
+        try {
+            authenticationService.authenticate(userNode.getPath(), authenticationOptions, authContext.getRequest(),
+                    authContext.getResponse());
 
-        JahiaUser jahiaUser = userNode.getJahiaUser();
-
-        if (request.getSession(false) != null) {
-            request.getSession().invalidate();
+            // update the cache entry if a new session was created
+            if (!originalSessionId.equals(request.getSession().getId())) {
+                jahiaAuthMapperService.updateCacheEntry(originalSessionId, request.getSession().getId());
+            }
+            request.setAttribute(VALVE_RESULT, "ok");
+        } catch (InvalidSessionLoginException e) {
+            // should not happen as the check is disabled
+            throw new IllegalStateException("Unexpected InvalidSessionLoginException", e);
+        } catch (AccountNotFoundException e) {
+            // can only happen if the user was deleted after the lookup and before the authentication
+            logger.warn("User not found : {}", userNode.getPath());
+            request.setAttribute(VALVE_RESULT, "unknown_user");
         }
-
-        if (!originalSessionId.equals(request.getSession().getId())) {
-            jahiaAuthMapperService.updateCacheEntry(originalSessionId, request.getSession().getId());
-        }
-
-        // if there were saved session attributes, we restore them here.
-        restoreSessionAttributes(request, savedSessionAttributes);
-
-        request.setAttribute(VALVE_RESULT, "ok");
-        authContext.getSessionFactory().setCurrentUser(jahiaUser);
-
-        // do a switch to the user's preferred language
-        if (settingsBean.isConsiderPreferredLanguageAfterLogin()) {
-            Locale preferredUserLocale = UserPreferencesHelper.getPreferredLocale(userNode, LanguageCodeConverters.resolveLocaleForGuest(request));
-            request.getSession().setAttribute(Constants.SESSION_LOCALE, preferredUserLocale);
-        }
-
-        String useCookie = request.getParameter("useCookie");
-        if ((useCookie != null) && ("on".equals(useCookie))) {
-            // the user has indicated he wants to use cookie authentication
-            CookieAuthValveImpl.createAndSendCookie(authContext, userNode, settingsBean.getCookieAuthConfig());
-        }
-
-        Map<String, Object> m = new HashMap<>();
-        m.put("user", jahiaUser);
-        m.put("authContext", authContext);
-        m.put("source", this);
-        FrameworkService.sendEvent("org/jahia/usersgroups/login/LOGIN", m, false);
     }
 
     private String findUserId(Map<String, Map<String, MappedProperty>> allMapperResult) {
@@ -146,30 +133,6 @@ public class SSOValve extends BaseAuthValve {
         return null;
     }
 
-    private Map<String, Serializable> preserveSessionAttributes(HttpServletRequest httpServletRequest) {
-        Map<String, Serializable> savedSessionAttributes = new HashMap<>();
-        if ((preserveSessionAttributes != null) && (httpServletRequest.getSession(false) != null) && (preserveSessionAttributes.length() > 0)) {
-            String[] sessionAttributeNames = Patterns.TRIPLE_HASH.split(preserveSessionAttributes);
-            HttpSession session = httpServletRequest.getSession(false);
-            for (String sessionAttributeName : sessionAttributeNames) {
-                Object attributeValue = session.getAttribute(sessionAttributeName);
-                if (attributeValue instanceof Serializable) {
-                    savedSessionAttributes.put(sessionAttributeName, (Serializable) attributeValue);
-                }
-            }
-        }
-        return savedSessionAttributes;
-    }
-
-    private void restoreSessionAttributes(HttpServletRequest httpServletRequest, Map<String, Serializable> savedSessionAttributes) {
-        if (savedSessionAttributes.size() > 0) {
-            HttpSession session = httpServletRequest.getSession();
-            for (Map.Entry<String, Serializable> savedSessionAttribute : savedSessionAttributes.entrySet()) {
-                session.setAttribute(savedSessionAttribute.getKey(), savedSessionAttribute.getValue());
-            }
-        }
-    }
-
     public void setJahiaAuthMapperService(JahiaAuthMapperService jahiaAuthMapperService) {
         this.jahiaAuthMapperService = jahiaAuthMapperService;
     }
@@ -178,9 +141,13 @@ public class SSOValve extends BaseAuthValve {
         this.jahiaUserManagerService = jahiaUserManagerService;
     }
 
+    /**
+     *
+     * @deprecated not used anymore
+     */
+    @Deprecated(since = "8.2.3.0", forRemoval = true)
     public void setSettingsBean(SettingsBean settingsBean) {
-        this.settingsBean = settingsBean;
-        this.preserveSessionAttributes = settingsBean.getString("preserveSessionAttributesOnLogin", "wemSessionId");
+        // ignored
     }
 
     public void setAuthPipeline(Pipeline authPipeline) {

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,6 @@
     <bean id="ssoValve" class="org.jahia.modules.jahiaauth.valves.SSOValve" init-method="start" destroy-method="stop">
         <property name="jahiaAuthMapperService" ref="jahiaAuthMapperServiceImpl"/>
         <property name="jahiaUserManagerService" ref="JahiaUserManagerService"/>
-        <property name="settingsBean" ref="settingsBean"/>
         <property name="authPipeline" ref="authPipeline"/>
         <property name="authenticationService" ref="authenticationService"/>
     </bean>

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,6 +12,7 @@
     <reference id="JahiaUserManagerService" interface="org.jahia.api.usermanager.JahiaUserManagerService"
                availability="mandatory"/>
     <reference id="authPipeline" interface="org.jahia.pipelines.Pipeline" filter="(type=authentication)"/>
+    <reference id="authenticationService" interface="org.jahia.services.security.AuthenticationService"/>
 
     <service id="jahiaAuthMapperServiceOsgi" ref="jahiaAuthMapperServiceImpl"
              interface="org.jahia.modules.jahiaauth.service.JahiaAuthMapperService"/>
@@ -34,6 +35,7 @@
         <property name="jahiaUserManagerService" ref="JahiaUserManagerService"/>
         <property name="settingsBean" ref="settingsBean"/>
         <property name="authPipeline" ref="authPipeline"/>
+        <property name="authenticationService" ref="authenticationService"/>
     </bean>
 
     <service interface="org.jahia.bin.Action">
@@ -51,7 +53,7 @@
             <property name="requiredPermission" value="canSetupJahiaAuth"/>
             <property name="settingsService" ref="settingsService"/>
         </bean>
-    </service>    
+    </service>
 
     <service interface="org.jahia.bin.Action">
         <bean class="org.jahia.modules.jahiaauth.action.ReadMappers">
@@ -60,7 +62,7 @@
             <property name="settingsService" ref="settingsService"/>
         </bean>
     </service>
-    
+
     <service interface="org.jahia.bin.Action">
         <bean class="org.jahia.modules.jahiaauth.action.WriteMappers">
             <property name="name" value="writeMappersAction"/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

Closes https://github.com/Jahia/jahia-private/issues/4374.

## Description
Migrates `SSOValve` authentication logic to use the centralized `AuthenticationService`, eliminating code duplication and improving maintainability while maintaining full backward compatibility.

## Changes
- **Update the minimal Jahia version** to 8.2.3.0 (from 8.1.3.0) for 1.9.x versions.
  - a 1.8.x maintenance branch will have to created in case of security fixes/patches to apply on 1.8.0
  - a JDK 11 is now required for the Maven build
- **Refactored authentication flow** to delegate to `AuthenticationService.authenticate()` instead of manual session management
- **Replaced manual validation** with `AuthenticationService.validateUserNode()` for consistent account and license checks
- **Removed duplicate code** for session handling, locale updates, cookie management, and login events (now centralized in `AuthenticationService`)
- **Disabled session validity check** in this valve (check performed later in `SessionAuthValveImpl` to avoid duplication)
- **Deprecated `setSettingsBean()`** method as it's no longer needed

