### PR TITLE
chore: Bump to 2.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <artifactId>jahia-authentication</artifactId>
     <name>Jahia Authentication</name>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Jahia OAuth) for running on a Digital Experience Manager server.</description>
 
@@ -68,7 +68,7 @@
     <properties>
         <export-package>org.jahia.modules.jahiaauth.service,org.jahia.modules.jahiaauth.action,org.jahia.modules.jahiaauth.tag</export-package>
         <jahia-static-resources>/css,/javascript,/icons</jahia-static-resources>
-        <jahia-module-signature>MCwCFFIZCgIsKdnWHPgPjJ2dwJDXBwRRAhQEvY2Ex5qXwvcMQOP36o+l9nfQOQ==</jahia-module-signature>
+        <jahia-module-signature>MCwCFEyTvPiYOs19tEURxHlAyv/feN+TAhRrjAB+dt2AowafE90v7TcEPCNHfg==</jahia-module-signature>
         <jahia.modules.importPackage>!com.hazelcast.config,!com.hazelcast.core</jahia.modules.importPackage>
         <sonar.sources>src/main/resources/javascript</sonar.sources>
         <yarn.arguments>build:production</yarn.arguments>


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-oauth/issues/120.
## Description

Since https://github.com/Jahia/jahia-authentication/pull/71, the module depends on Jahia 8.2.3.0-SN.
https://github.com/Jahia/jahia-authentication/tree/1_x has been created as a maintenance branch (1.8.0 being the latest release as of today), while `master` should be bumped to `2.0.0-SN`.

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
